### PR TITLE
⚡📦 Lote validado por cache, sin Rebanadas

### DIFF
--- a/models/stock_production_lot.py
+++ b/models/stock_production_lot.py
@@ -27,6 +27,7 @@ class ProductionLot(models.Model):
                 ('location_id.usage', '=', 'internal'),
                 ('quantity', '>', 0),
                 ('lot_id', '!=', False),
+                ('x_studio_categoria_de_producto', '!=', "Rebanadas"),
             ],
             fields=['lot_id'],
             groupby=['lot_id']


### PR DESCRIPTION
Se requiere que los lotes destinados a productos en forma de rebanadas no sean cargados.